### PR TITLE
Fix for destroyAll

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -631,7 +631,7 @@ function destroyAll(model, where, callback) {
         return;
       }
       var tasks = [];
-      results.forEach(function(result) {
+      results.filter(Boolean).forEach(function(result) {
         tasks.push(function(done) { br.destroy(model, result.id, done); });
       });
       async.parallel(tasks, callback);


### PR DESCRIPTION
### Description

`results` was returning back `[null]` whenever `this.all` could not find an element matching the specified `where` clause.  The source of where the `[null]` comes from is the npm `redis` module.
 
#### Related issues

https://github.com/strongloop-community/loopback-connector-redis/issues/38
