### PR TITLE
Fix for error-logging if error is not a string

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -53,7 +53,7 @@ exports.initialize = function initializeSchema(dataSource, callback) {
     }
   });
   dataSource.client.on('error', function(error) {
-    g.log(error);
+    g.log(String(error));
   });
 
   var clientWrapper = new Client(dataSource.client);


### PR DESCRIPTION
### Description

Cast error to string before feeding it to g.log()

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #51

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
