### PR TITLE
Settings bug fix when passing an host without a port

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -23,18 +23,17 @@ exports.initialize = function initializeSchema(dataSource, callback) {
     }
   }
 
-  var params = [];
+  if (!dataSource.settings.options) {
+    dataSource.settings.options = {};
+  }
   if (dataSource.settings.port) {
-    params.push(dataSource.settings.port);
+    dataSource.settings.options.port = dataSource.settings.port;
   }
   if (dataSource.settings.host) {
-    params.push(dataSource.settings.host);
-  }
-  if (dataSource.settings.options) {
-    params.push(dataSource.settings.options);
+    dataSource.settings.options.host = dataSource.settings.host;
   }
 
-  dataSource.client = redis.createClient.apply(redis.createClient, params);
+  dataSource.client = redis.createClient(dataSource.settings.options);
   dataSource.client.auth(dataSource.settings.password);
   var callbackCalled = false;
   var database = dataSource.settings.hasOwnProperty('database') &&


### PR DESCRIPTION
The redis client doesn't get created when only the host setting is passed. 