### PR TITLE
unstringify data field on read.

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -273,7 +273,10 @@ BridgeToRedis.prototype.fromDb = function(model, data, fields) {
       delete data[i];
       continue;
     }
-    if (!p[i]) continue;
+    if (!p[i]) {
+      data[i] = JSON.parse(data[i]);
+      continue;
+    }
     if (!data[i]) {
       data[i] = '';
       continue;


### PR DESCRIPTION
When a model's field has no property definition, we unconditionally stringify the field on write.
If the field data is a string, it gets quoted again. On read we don't undo the stringification.
A string data field becomes a string with extra quotes. read & write need be symmetrical.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
